### PR TITLE
create item-index-function

### DIFF
--- a/app/assets/stylesheets/_index.scss
+++ b/app/assets/stylesheets/_index.scss
@@ -170,6 +170,7 @@
     &__heading{
       font-size: 28px;
       text-align:center;
+      font-weight:bold;
     }
     &__item{
       width: 940px;
@@ -178,6 +179,7 @@
         font-size: 22px;
         margin: 26px 11px;
         text-align: center;
+        font-weight:bold;
         &__title{
           color: #0099e8;
           text-decoration: none;
@@ -186,6 +188,7 @@
       &__box{
         width: auto;
         margin: 0 auto;
+        display:inline-block;
         &__content{
           margin: 0 0 0 15px;
           width: 213px;
@@ -194,6 +197,10 @@
             &__figure{
               width: 213px;
               height: 220px;
+              &__image{
+                width: 213px;
+                height: 220px;
+              }
             }
             &__body{
               padding: 16px;
@@ -203,10 +210,12 @@
                 overflow: hidden;
                 position: relative;
                 font-weight: 400;
+                font-size: 16px;
                 height: 3em;
                 line-height: 1.5;
                 word-break: break-word;
                 white-space: normal;
+                text-align:left;
               }
               &__num{
                 display: flex;
@@ -221,6 +230,7 @@
               }
               &__tax{
                 font-size: 10px;
+                text-align:left;
               }
             }
           }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,14 +3,14 @@ class ItemsController < ApplicationController
 
   def index
     @item = Item.new
-    @ladies = Item.recent.limit(4).where(category_id:1)
-    @mens = Item.recent.limit(4).where(category_id:2)
-    @babies = Item.recent.limit(4).where(category_id:3)
-    @cosmes =Item.recent.limit(4).where(category_id:4)
-    @chanels =Item.recent.limit(4).where(category_id:5)
-    @louis =Item.recent.limit(4).where(category_id:6)
-    @supremes =Item.recent.limit(4).where(category_id:7)
-    @nikes =Item.recent.limit(4).where(category_id:8)
+    @ladies = Item.recent.where(category_id:1)
+    @mens = Item.recent.where(category_id:2)
+    @babies = Item.recent.where(category_id:3)
+    @cosmes =Item.recent.where(category_id:4)
+    @chanels =Item.recent.where(category_id:5)
+    @louis =Item.recent.where(category_id:6)
+    @supremes =Item.recent.where(category_id:7)
+    @nikes =Item.recent.where(category_id:8)
   end
   # def delete
   # end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,17 @@
 class ItemsController < ApplicationController
-  def index
-  end
+  # before_action :set_category
 
+  def index
+    @item = Item.new
+    @ladies = Item.order('id DESC').limit(4).where(category_id:1)
+    @mens = Item.order('id DESC').limit(4).where(category_id:2)
+    @babies = Item.order('id DESC').limit(4).where(category_id:3)
+    @cosmes =Item.order('id DESC').limit(4).where(category_id:4)
+    @chanels =Item.order('id DESC').limit(4).where(category_id:5)
+    @louis =Item.order('id DESC').limit(4).where(category_id:6)
+    @supremes =Item.order('id DESC').limit(4).where(category_id:7)
+    @nikes =Item.order('id DESC').limit(4).where(category_id:8)
+  end
   # def delete
   # end
 
@@ -15,6 +25,15 @@ class ItemsController < ApplicationController
   end
 
   def buy
+  end
+
+  private
+  def create_params
+    params.require(:item).permit(:name,:price,:description,:status).merge(image_id: params[:image_id])
+  end
+
+  def set_category
+    @category = Category.find(params[:category_id])
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,14 +3,14 @@ class ItemsController < ApplicationController
 
   def index
     @item = Item.new
-    @ladies = Item.order('id DESC').limit(4).where(category_id:1)
-    @mens = Item.order('id DESC').limit(4).where(category_id:2)
-    @babies = Item.order('id DESC').limit(4).where(category_id:3)
-    @cosmes =Item.order('id DESC').limit(4).where(category_id:4)
-    @chanels =Item.order('id DESC').limit(4).where(category_id:5)
-    @louis =Item.order('id DESC').limit(4).where(category_id:6)
-    @supremes =Item.order('id DESC').limit(4).where(category_id:7)
-    @nikes =Item.order('id DESC').limit(4).where(category_id:8)
+    @ladies = Item.recent.limit(4).where(category_id:1)
+    @mens = Item.recent.limit(4).where(category_id:2)
+    @babies = Item.recent.limit(4).where(category_id:3)
+    @cosmes =Item.recent.limit(4).where(category_id:4)
+    @chanels =Item.recent.limit(4).where(category_id:5)
+    @louis =Item.recent.limit(4).where(category_id:6)
+    @supremes =Item.recent.limit(4).where(category_id:7)
+    @nikes =Item.recent.limit(4).where(category_id:8)
   end
   # def delete
   # end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,2 +1,5 @@
 module ItemsHelper
+  def converting_to_mark(price)
+    "¥#{price}"
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,5 +6,5 @@ class Item < ApplicationRecord
   belongs_to :user
   belongs_to :prefecture
   
-  scope :recent, -> {order('id DESC')}
+  scope :recent, -> {order('id DESC').limit(4)}
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,4 +5,6 @@ class Item < ApplicationRecord
   belongs_to :brand
   belongs_to :user
   belongs_to :prefecture
+  
+  scope :recent, -> {order('id DESC')}
 end

--- a/app/views/items/_item_index.html.haml
+++ b/app/views/items/_item_index.html.haml
@@ -1,0 +1,13 @@
+.pickup__item__box
+  .pickup__item__box__content
+    =link_to "items/show" do
+      .pickup__item__box__content__link
+        .pickup__item__box__content__link__figure
+          = image_tag "#{item.images[0].text}",class: "pickup__item__box__content__link__figure__image"
+        .pickup__item__box__content__link__body
+          %h3.pickup__item__box__content__link__body__name 
+            = item.name
+          .pickup__item__box__content__link__body__num
+            .pickup__item__box__content__link__body__num__price 
+              = converting_to_mark(item.price)
+          %p.pickup__item__box__content__link__body__tax (税込)

--- a/app/views/items/_item_index.html.haml
+++ b/app/views/items/_item_index.html.haml
@@ -1,6 +1,6 @@
 .pickup__item__box
   .pickup__item__box__content
-    =link_to "items/show" do
+    =link_to items_path,method: :get do
       .pickup__item__box__content__link
         .pickup__item__box__content__link__figure
           = image_tag "#{item.images[0].text}",class: "pickup__item__box__content__link__figure__image"

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -3,7 +3,6 @@
   .main
     .carousel
       .carousel__image
-      -# = image_tag "https://www-mercari-jp.akamaized.net/assets/img/common/jp/top/main_content_pc.png?582218381", size: "390x1000", alt: "カルーセル（仮）", class: "carousel__image"
     .pickup
       %h2.pickup__heading ピックアップカテゴリー
       .pickup__item
@@ -12,47 +11,6 @@
             .pickup__item__category__title  レディース新着アイテム
         - @ladies.each do |item|
           = render partial:"item_index",locals: {item: item}
-        -# .pickup__item__box
-        -#   .pickup__item__box__content
-        -#     =link_to "#" do
-        -#       .pickup__item__box__content__link
-        -#         .pickup__item__box__content__link__figure
-        -#           = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
-        -#         .pickup__item__box__content__link__body
-        -#           %h3.pickup__item__box__content__link__body__name Tシャツ
-        -#           .pickup__item__box__content__link__body__num
-        -#             .pickup__item__box__content__link__body__num__price￥5,000
-        -#           %p.pickup__item__box__content__link__body__tax （税込）
-        -#   .pickup__item__box__content
-        -#     =link_to "#" do
-        -#       .pickup__item__box__content__link
-        -#         .pickup__item__box__content__link__figure
-        -#           = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
-        -#         .pickup__item__box__content__link__body
-        -#           %h3.pickup__item__box__content__link__body__name Tシャツ
-        -#           .pickup__item__box__content__link__body__num
-        -#             .pickup__item__box__content__link__body__num__price￥5,000
-        -#           %p.pickup__item__box__content__link__body__tax （税込）
-        -#   .pickup__item__box__content
-        -#     =link_to "#" do
-        -#       .pickup__item__box__content__link
-        -#         .pickup__item__box__content__link__figure
-        -#           = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
-        -#         .pickup__item__box__content__link__body
-        -#           %h3.pickup__item__box__content__link__body__name Tシャツ
-        -#           .pickup__item__box__content__link__body__num
-        -#             .pickup__item__box__content__link__body__num__price￥5,000
-        -#           %p.pickup__item__box__content__link__body__tax （税込）
-        -#   .pickup__item__box__content
-        -#     =link_to "#" do
-        -#       .pickup__item__box__content__link
-        -#         .pickup__item__box__content__link__figure
-        -#           = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
-        -#         .pickup__item__box__content__link__body
-        -#           %h3.pickup__item__box__content__link__body__name Tシャツ
-        -#           .pickup__item__box__content__link__body__num
-        -#             .pickup__item__box__content__link__body__num__price￥5,000
-        -#           %p.pickup__item__box__content__link__body__tax（税込）
         .pickup__item__all
           =link_to "#" do
             %p.pickup__item__all__link 全ての商品を見る
@@ -121,7 +79,6 @@
         .pickup__item__all
           =link_to "#" do
             %p.pickup__item__all__link 全ての商品を見る
-
   .aside
     .aside__banner
       .aside__banner__left

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -10,47 +10,49 @@
         %h3.pickup__item__category
           =link_to "#" do
             .pickup__item__category__title  レディース新着アイテム
-        .pickup__item__box
-          .pickup__item__box__content
-            =link_to "#" do
-              .pickup__item__box__content__link
-                .pickup__item__box__content__link__figure
-                  = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
-                .pickup__item__box__content__link__body
-                  %h3.pickup__item__box__content__link__body__name Tシャツ
-                  .pickup__item__box__content__link__body__num
-                    .pickup__item__box__content__link__body__num__price￥5,000
-                  %p.pickup__item__box__content__link__body__tax （税込）
-          .pickup__item__box__content
-            =link_to "#" do
-              .pickup__item__box__content__link
-                .pickup__item__box__content__link__figure
-                  = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
-                .pickup__item__box__content__link__body
-                  %h3.pickup__item__box__content__link__body__name Tシャツ
-                  .pickup__item__box__content__link__body__num
-                    .pickup__item__box__content__link__body__num__price￥5,000
-                  %p.pickup__item__box__content__link__body__tax （税込）
-          .pickup__item__box__content
-            =link_to "#" do
-              .pickup__item__box__content__link
-                .pickup__item__box__content__link__figure
-                  = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
-                .pickup__item__box__content__link__body
-                  %h3.pickup__item__box__content__link__body__name Tシャツ
-                  .pickup__item__box__content__link__body__num
-                    .pickup__item__box__content__link__body__num__price￥5,000
-                  %p.pickup__item__box__content__link__body__tax （税込）
-          .pickup__item__box__content
-            =link_to "#" do
-              .pickup__item__box__content__link
-                .pickup__item__box__content__link__figure
-                  = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
-                .pickup__item__box__content__link__body
-                  %h3.pickup__item__box__content__link__body__name Tシャツ
-                  .pickup__item__box__content__link__body__num
-                    .pickup__item__box__content__link__body__num__price￥5,000
-                  %p.pickup__item__box__content__link__body__tax（税込）
+        - @ladies.each do |item|
+          = render partial:"item_index",locals: {item: item}
+        -# .pickup__item__box
+        -#   .pickup__item__box__content
+        -#     =link_to "#" do
+        -#       .pickup__item__box__content__link
+        -#         .pickup__item__box__content__link__figure
+        -#           = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
+        -#         .pickup__item__box__content__link__body
+        -#           %h3.pickup__item__box__content__link__body__name Tシャツ
+        -#           .pickup__item__box__content__link__body__num
+        -#             .pickup__item__box__content__link__body__num__price￥5,000
+        -#           %p.pickup__item__box__content__link__body__tax （税込）
+        -#   .pickup__item__box__content
+        -#     =link_to "#" do
+        -#       .pickup__item__box__content__link
+        -#         .pickup__item__box__content__link__figure
+        -#           = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
+        -#         .pickup__item__box__content__link__body
+        -#           %h3.pickup__item__box__content__link__body__name Tシャツ
+        -#           .pickup__item__box__content__link__body__num
+        -#             .pickup__item__box__content__link__body__num__price￥5,000
+        -#           %p.pickup__item__box__content__link__body__tax （税込）
+        -#   .pickup__item__box__content
+        -#     =link_to "#" do
+        -#       .pickup__item__box__content__link
+        -#         .pickup__item__box__content__link__figure
+        -#           = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
+        -#         .pickup__item__box__content__link__body
+        -#           %h3.pickup__item__box__content__link__body__name Tシャツ
+        -#           .pickup__item__box__content__link__body__num
+        -#             .pickup__item__box__content__link__body__num__price￥5,000
+        -#           %p.pickup__item__box__content__link__body__tax （税込）
+        -#   .pickup__item__box__content
+        -#     =link_to "#" do
+        -#       .pickup__item__box__content__link
+        -#         .pickup__item__box__content__link__figure
+        -#           = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
+        -#         .pickup__item__box__content__link__body
+        -#           %h3.pickup__item__box__content__link__body__name Tシャツ
+        -#           .pickup__item__box__content__link__body__num
+        -#             .pickup__item__box__content__link__body__num__price￥5,000
+        -#           %p.pickup__item__box__content__link__body__tax（税込）
         .pickup__item__all
           =link_to "#" do
             %p.pickup__item__all__link 全ての商品を見る
@@ -58,27 +60,64 @@
         %h3.pickup__item__category
           =link_to "#" do
             .pickup__item__category__title  メンズ新着アイテム
-        .pickup__item__box
-          .pickup__item__box__content
-            =link_to "#" do
-              .pickup__item__box__content__link
-                .pickup__item__box__content__link__figure
-                  = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
-                .pickup__item__box__content__link__body
-                  %h3.pickup__item__box__content__link__body__name Tシャツ
-                  .pickup__item__box__content__link__body__num
-                    .pickup__item__box__content__link__body__num__price￥5,000
-                  %p.pickup__item__box__content__link__body__tax（税込）
-          .pickup__item__box__content
-            =link_to "#" do
-              .pickup__item__box__content__link
-                .pickup__item__box__content__link__figure
-                  = image_tag "item-t_shirt.jpg", size: "213x220", alt: "商品（仮）", class: "pickup__item__box__content__link__figure__image"
-                .pickup__item__box__content__link__body
-                  %h3.pickup__item__box__content__link__body__name Tシャツ
-                  .pickup__item__box__content__link__body__num
-                    .pickup__item__box__content__link__body__num__price￥5,000
-                  %p.pickup__item__box__content__link__body__tax (税込)
+        - @mens.each do |item|
+          = render partial:"item_index",locals: {item: item}
+        .pickup__item__all
+          =link_to "#" do
+            %p.pickup__item__all__link 全ての商品を見る
+      .pickup__item
+        %h3.pickup__item__category
+          =link_to "#" do
+            .pickup__item__category__title  ベビー・キッズ新着アイテム
+        - @babies.each do |item|
+          = render partial:"item_index",locals: {item: item}
+        .pickup__item__all
+          =link_to "#" do
+            %p.pickup__item__all__link 全ての商品を見る
+      .pickup__item
+        %h3.pickup__item__category
+          =link_to "#" do
+            .pickup__item__category__title  コスメ・香水・美容 新着アイテム
+        - @cosmes.each do |item|
+          = render partial:"item_index",locals: {item: item}
+        .pickup__item__all
+          =link_to "#" do
+            %p.pickup__item__all__link 全ての商品を見る
+    .pickup
+      %h2.pickup__heading ピックアップブランド
+      .pickup__item
+        %h3.pickup__item__category
+          =link_to "#" do
+            .pickup__item__category__title  シャネル新着アイテム
+        - @chanels.each do |item|
+          = render partial:"item_index",locals: {item: item}
+        .pickup__item__all
+          =link_to "#" do
+            %p.pickup__item__all__link 全ての商品を見る
+      .pickup__item
+        %h3.pickup__item__category
+          =link_to "#" do
+            .pickup__item__category__title  ルイヴィトン 新着アイテム
+        - @louis.each do |item|
+          = render partial:"item_index",locals: {item: item}
+        .pickup__item__all
+          =link_to "#" do
+            %p.pickup__item__all__link 全ての商品を見る
+      .pickup__item
+        %h3.pickup__item__category
+          =link_to "#" do
+            .pickup__item__category__title  シュプリーム 新着アイテム
+        - @supremes.each do |item|
+          = render partial:"item_index",locals: {item: item}
+        .pickup__item__all
+          =link_to "#" do
+            %p.pickup__item__all__link 全ての商品を見る
+      .pickup__item
+        %h3.pickup__item__category
+          =link_to "#" do
+            .pickup__item__category__title  ナイキ 新着アイテム
+        - @nikes.each do |item|
+          = render partial:"item_index",locals: {item: item}
         .pickup__item__all
           =link_to "#" do
             %p.pickup__item__all__link 全ての商品を見る


### PR DESCRIPTION
# What
商品一覧表示機能の実装
商品出品機能が未実装なので、手動でデーターベースにデータを入力
pickup-item-boxの部分テンプレート化
各カテゴリーごとの表示機能の実装

# Why
各カテゴリーを選択しやすくするため。
