### PR TITLE
検索結果画面のビュー、リンクの修正

### DIFF
--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -3,7 +3,7 @@
   text-decoration:none;
 }
 .wrapper-search {
-  height: 1300px;
+  height: 1500px;
   width: 100vw;
   background-color: #f5f5f5;
   .container {
@@ -21,12 +21,270 @@
         background-color: #fff;
         border-radius: 4px;
         line-height: 40px;
+        &__box {
+          margin-left: 10px;
+        }
+        &__down-icon {
+          position: absolute;
+          left: 250px;
+          top: 235px;
+          font-size: 8px;
+          transform: translate(0, -50%);
+          .fa.fa-chevron-down {
+            font-size: 17px;
+            color: #a9a9a9;
+          }
+        }
       }
       &__search-area {
-        height: 800px;
+        height: 1000px;
         width: 285px;
         background-color: #fff;
         margin-top: 40px;
+        &__box {
+          height: 780px;
+          width: 265px;
+          margin: 15px auto;
+          &__detail {
+            font-size: 16px;
+            font-weight: bold;
+            padding-top: 5px;
+          }
+          &__keyword {
+            margin-top: 8px;
+            &__add-to {
+              font-size: 13px;
+            }
+            &__select {
+              margin-top: 5px;
+              &__box {
+                height: 47px;
+                width: 250px;
+                border-radius: 4px;
+                border: 1px solid #a9a9a9;
+                padding-left: 15px;
+              }
+            }
+          }
+          &__category {
+            margin-top: 30px;
+            &__select {
+              font-size: 13px;
+            }
+            &__select-box {
+              margin-top: 3px;
+              &__pull-down {
+                position: relative;
+                height: 47px;
+                width: 250px;
+                padding-left: 10px;
+                background-color: #fff;
+                border: solid 1px #d3d3d3;
+                -webkit-appearance: none;
+                font-size: 16px;
+                cursor: pointer;
+                margin-bottom: 30px;
+              }
+              &__down-icon-category {
+                position: absolute;
+                left: 240px;
+                top: 480px;
+                font-size: 8px;
+                transform: translate(0, -50%);      
+                .fa.fa-chevron-down {
+                  font-size: 17px;
+                  color: #a9a9a9;
+                }
+              }
+            }
+          }
+          &__brand {
+            margin-top: 6px;
+            &__text {
+              font-size: 13px;
+            }
+            &__search {
+              margin-top: 6px;
+              &__input {
+                height: 47px;
+                width: 250px;
+                border-radius: 4px;
+                border: 1px solid #a9a9a9;
+                padding-left: 15px;
+              }
+            }
+          }
+          &__size {
+            margin-top: 33px;
+            font-size: 13px;
+            &__text {
+              margin-bottom: 5px;
+            }
+            &__input {
+              &__pull-down {
+                position: relative;
+                height: 47px;
+                width: 250px;
+                padding-left: 10px;
+                background-color: #fff;
+                border: solid 1px #d3d3d3;
+                -webkit-appearance: none;
+                font-size: 16px;
+                cursor: pointer;
+                margin-bottom: 30px;
+              }
+              &__icon {
+                position: absolute;
+                left: 240px;
+                top: 695px;
+                font-size: 8px;
+                transform: translate(0, -50%);      
+                .fa.fa-chevron-down {
+                  font-size: 17px;
+                  color: #a9a9a9;
+                }
+              }
+            }
+          }
+          &__price {
+            margin-top: 5px;
+            font-size: 13px;
+            &__text {
+              margin-bottom: 3px;
+            }
+            &__input {
+              &__pull-down {
+                position: relative;
+                height: 47px;
+                width: 250px;
+                padding-left: 10px;
+                background-color: #fff;
+                border: solid 1px #d3d3d3;
+                -webkit-appearance: none;
+                font-size: 16px;
+                cursor: pointer;
+                margin-bottom: 30px;
+              }
+              &__icon {
+                position: absolute;
+                left: 240px;
+                top: 800px;
+                font-size: 8px;
+                transform: translate(0, -50%);      
+                .fa.fa-chevron-down {
+                  font-size: 17px;
+                  color: #a9a9a9;
+                }
+              }
+            }
+            &__input-left {
+              display: inline-block;
+              &__min {
+                position: relative;
+                height: 47px;
+                width: 117px;
+                padding-left: 10px;
+                background-color: #fff;
+                border: solid 1px #d3d3d3;
+                -webkit-appearance: none;
+                font-size: 16px;
+                cursor: pointer;
+                margin-bottom: 30px;
+                border-radius: 4px;
+              }
+            }
+            &__space {
+              display: inline-block;
+            }
+            &__input-right {
+              display: inline-block;
+              &__max {
+                position: relative;
+                height: 47px;
+                width: 117px;
+                padding-left: 10px;
+                background-color: #fff;
+                border: solid 1px #d3d3d3;
+                -webkit-appearance: none;
+                font-size: 16px;
+                cursor: pointer;
+                margin-bottom: 30px;
+                border-radius: 4px;
+              }
+            }
+          }
+          &__status {
+            &__text {
+              font-size: 13px;
+            }
+            &__check-box {
+              height: 150px;
+              color: #696969;
+              &__default {
+                font-size: 12px;
+                display: inline-block;
+                #checbox1 {
+                  margin-left: 37px;
+                }
+                .icon-check {
+                  margin-left: 72px;
+                }
+                %label {
+                  width: 50px;
+                  white-space: pre-wrap;
+                }
+              }
+            }
+          }
+          &__shipping {
+            &__text {
+              font-size: 13px;
+            }
+            &__check {
+              &__box {
+                font-size: 12px;
+                color: #696969;
+                display: inline-block;
+              }
+            }
+          }
+          &__sall {
+            margin-top: 15px;
+            &__text {
+              font-size: 13px;
+            }
+            &__check {
+              &__box {
+                font-size: 12px;
+                color: #696969;
+                display: inline-block;
+              }
+            }
+          }
+          &__button {
+            height: 100px;
+            width: 270px;
+            line-height: 50px;
+            margin-top: 30px;
+            &__left {
+              text-align: center;
+              color: #fff;
+              height: 50px;
+              width: 100px;
+              display: inline-block;
+              background-color: #a9a9a9;
+            }
+            &__right {
+              text-align: center;
+              color: #fff;
+              height: 50px;
+              width: 100px;
+              display: inline-block;
+              background-color: red;
+              margin-left: 30px;
+            }
+          }
+        }
       }
     }
     &__right {
@@ -37,10 +295,15 @@
         height: 45px;
         &__item-name {
           display: inline-block;
-          font-size: 25px;
+          font-size: 32px;
           font-weight: bold;
         }
-        &__text {
+        .item-result {
+          font-size: 21px;
+          font-weight: bold;
+          display: inline-block;
+        }
+        .item-result-sub {
           display: inline-block;
         }
       }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 
 class ItemsController < ApplicationController
   # before_action :authenticate_user!, only:[:index,:show]
-  before_action :move_to_sign_in,except: [:index,:show]
+  before_action :move_to_sign_in,except: [:index,:show, :search]
   before_action :set_search
 
   def index

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -7,16 +7,148 @@
       .container__left__sort-area
         .container__left__sort-area__box
           並び替え
-      
+        .container__left__sort-area__down-icon
+          %i.fa.fa-chevron-down
+
       .container__left__search-area
         .container__left__search-area__box
+          .container__left__search-area__box__detail
+            詳細検索
+          .container__left__search-area__box__keyword
+            .container__left__search-area__box__keyword__add-to
+              %i.fa.fa-plus
+              キーワードを追加する
+            .container__left__search-area__box__keyword__select
+              %input.container__left__search-area__box__keyword__select__box{placeholder: '例）値下げ'}
+          .container__left__search-area__box__category
+            .container__left__search-area__box__category__select
+              %i.fa.fa-list-ul
+              カテゴリーを選択する
+            .container__left__search-area__box__category__select-box
+              %select.container__left__search-area__box__category__select-box__pull-down
+                %option{value: "すべて"} すべて
+                %option{value: "レディース"} レディース
+                %option{value: "メンズ"} メンズ
+                %option{value: "ベビー・キッズ"} ベビー・キッズ
+                %option{value: "インテリア・住まい・小物"} インテリア・住まい・小物
+              .container__left__search-area__box__category__select-box__down-icon-category
+                %i.fa.fa-chevron-down
+          .container__left__search-area__box__brand
+            .container__left__search-area__box__brand__text
+              %i.fa.fa-tag
+              ブランド名から探す
+            .container__left__search-area__box__brand__search
+              %input.container__left__search-area__box__brand__search__input{placeholder: '例）シャネル'}
+          .container__left__search-area__box__size
+            .container__left__search-area__box__size__text
+              %i.fa.fa-simplybuilt
+              サイズを指定する
+            .container__left__search-area__box__size__input
+              %select.container__left__search-area__box__size__input__pull-down
+                %option{value: "すべて"} すべて
+                %option{value: "洋服のサイズ"} 洋服のサイズ
+                %option{value: "メンズ靴のサイズ"} メンズ靴のサイズ
+                %option{value: "レディース靴のサイズ"} レディース靴のサイズ
+                %option{value: "スカートのサイズ"} スカートのサイズ
+                %option{value: "キッズ服のサイズ"} キッズ服のサイズ
+                %option{value: "ベビー・キッズ靴のサイズ"} ベビー・キッズ靴のサイズ
+                %option{value: "ベビー服のサイズ"} ベビー服のサイズ
+                %option{value: "沢井くんのサイズ"} 沢井くんのサイズ
+              .container__left__search-area__box__size__input__icon
+                %i.fa.fa-chevron-down
+          .container__left__search-area__box__price
+            .container__left__search-area__box__price__text
+              %i.fa.fa-bitcoin
+              価格
+            .container__left__search-area__box__price__input
+              %select.container__left__search-area__box__price__input__pull-down
+                %option{value: "選択してください"} 選択してください
+                %option{value: "300~1000"} 300~1000
+                %option{value: "1000~5000"} 1000~5000
+                %option{value: "5000~10000"} 5000~10000
+              .container__left__search-area__box__price__input__icon
+                %i.fa.fa-chevron-down
+            .container__left__search-area__box__price__input-left
+              %input.container__left__search-area__box__price__input-left__min{placeholder: '¥Min'}
+            .container__left__search-area__box__price__space
+              = "~"
+            .container__left__search-area__box__price__input-right
+              %input.container__left__search-area__box__price__input-right__max{placeholder: '¥Max'}
+          .container__left__search-area__box__status
+            .container__left__search-area__box__status__text
+              %i.fa.fa-star
+                商品の状態
+            .container__left__search-area__box__status__check-box
+              .container__left__search-area__box__status__check-box__default
+                %input{type: 'checkbox', class: 'icon-check-left'}
+                %label すべて
+              .container__left__search-area__box__status__check-box__default
+                %input{type: 'checkbox', class: 'icon-check'}
+                %label 新品、未使用
+              .container__left__search-area__box__status__check-box__default
+                %input{type: 'checkbox', id: 'checbox2'}
+                %label 未使用に近い
+              .container__left__search-area__box__status__check-box__default
+                %input{type: 'checkbox',id: 'checbox1'}
+                %label
+                  目立った傷や
+                  %br
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;汚れなし
+              .container__left__search-area__box__status__check-box__default
+                %input{type: 'checkbox'}
+                %label ややキズや汚れあり
+              .container__left__search-area__box__status__check-box__default
+                %input{type: 'checkbox'}
+                  傷や汚れあり
+              .container__left__search-area__box__status__check-box__default
+                %input{type: 'checkbox'}
+                  全体的に状態が悪い
+          .container__left__search-area__box__shipping
+            .container__left__search-area__box__shipping__text
+              %i.fa.fa-truck
+                配送料の負担
+            .container__left__search-area__box__shipping__check
+              .container__left__search-area__box__shipping__check__box
+                %input{type: 'checkbox', class: 'icon-check-left'}
+                %label すべて
+              .container__left__search-area__box__shipping__check__box
+                %input{type: 'checkbox', class: 'icon-check-left'}
+                %label 着払い
+              .container__left__search-area__box__shipping__check__box
+                %input{type: 'checkbox', class: 'icon-check-left'}
+                %label 送料込み
+          .container__left__search-area__box__sall
+            .container__left__search-area__box__sall__text
+              %i.fa.fa-shopping-cart
+                販売状況
+            .container__left__search-area__box__sall__check
+              .container__left__search-area__box__sall__check__box
+                %input{type: 'checkbox', class: 'icon-check-left'}
+                %label すべて
+              .container__left__search-area__box__sall__check__box
+                %input{type: 'checkbox', class: 'icon-check-left'}
+                %label 販売中
+              .container__left__search-area__box__sall__check__box
+                %input{type: 'checkbox', class: 'icon-check-left'}
+                %label 売り切れ
+          .container__left__search-area__box__button
+            .container__left__search-area__box__button__left
+              クリア
+            .container__left__search-area__box__button__right
+              完了
 
     .container__right
       .container__right__search-result
         .container__right__search-result__item-name
-          = @q.name_cont
-        .container__right__search-result__text
-          の検索結果
+        - if @q.name_cont.present?
+          .item-result
+            = @q.name_cont
+          .item-result-sub
+            の検索結果
+        - else
+          .item-result
+            新着商品
+          
       .container__right__displayed-results
         .container__right__displayed-results__display
           = "1-#{@items.length}件表示"
@@ -24,9 +156,10 @@
         .container__right__search-item__results
           - @items.each do |item|
             .container__right__search-item__results__box
-              .container__right__search-item__results__box__image-box
-                = image_tag item.image.url, alt: "画像1", class: "owl-lazy"
-                .container__right__search-item__results__box__image-box__name-box
-                  = item.name
-                .container__right__search-item__results__box__image-box__price
-                  = converting_to_mark(item.price)
+              =link_to item_path(item.id),method: :get do
+                .container__right__search-item__results__box__image-box
+                  = image_tag item.image.url, alt: "画像1", class: "owl-lazy"
+                  .container__right__search-item__results__box__image-box__name-box
+                    = item.name
+                  .container__right__search-item__results__box__image-box__price
+                    = converting_to_mark(item.price)


### PR DESCRIPTION
# what
#### 実装したもの
　・検索結果ページの左部分のビュー実装（検索項目選択する部分）。
　・検索結果ページの各アイテムの詳細画面へのリンク貼りつけ。
　・ログインしていないユーザーでも検索可能。
　・画像のGIFです↓
　　https://gyazo.com/7ffa501d6ad4fe26166c267026aeb89c

# why
　・検索結果画面からのUI、UX向上のため。