### PR TITLE
商品詳細ページの画像スライド更新

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -14,6 +14,10 @@
               .section__main__box__owl-carousel__stage__outer__active
                 .section__main__box__owl-carousel__stage__outer__active__item-inner{ id: 'main' }
                   = image_tag @item.image.url, alt: "画像1", class: "owl-lazy"
+                  = image_tag @item.image.url, alt: "画像1", class: "owl-lazy"
+                  = image_tag @item.image.url, alt: "画像1", class: "owl-lazy"
+                  = image_tag @item.image.url, alt: "画像1", class: "owl-lazy"
+                  = image_tag @item.image.url, alt: "画像1", class: "owl-lazy"
                 -if @item.sales_status == "売却済み"
                   .section__main__box__owl-carousel__stage__outer__active__red
                   .section__main__box__owl-carousel__stage__outer__active__sold


### PR DESCRIPTION
# what
　・itemのshow.html.hamlを更新し、画像スライドの記述。
　　メイン画像を4枚加えました。
　・GIF画像↓
　　https://gyazo.com/d1a64f9e558ac68929ba83e9f74e7ef5

# why
　・画像スライドの画像数が足りなくなっていたため。