### PR TITLE
検索結果画面左側のアイコンの位置修正

### DIFF
--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -25,12 +25,11 @@
           margin-left: 10px;
         }
         &__down-icon {
-          position: absolute;
-          left: 250px;
-          top: 235px;
           font-size: 8px;
           transform: translate(0, -50%);
           .fa.fa-chevron-down {
+            margin-left: 260px;
+            margin-bottom: 42px;
             font-size: 17px;
             color: #a9a9a9;
           }
@@ -86,12 +85,12 @@
                 margin-bottom: 30px;
               }
               &__down-icon-category {
-                position: absolute;
-                left: 240px;
-                top: 480px;
                 font-size: 8px;
                 transform: translate(0, -50%);      
                 .fa.fa-chevron-down {
+                  position: absolute;
+                  right: 18px;
+                  bottom: 45px;
                   font-size: 17px;
                   color: #a9a9a9;
                 }
@@ -134,15 +133,14 @@
                 margin-bottom: 30px;
               }
               &__icon {
-                position: absolute;
-                left: 240px;
-                top: 695px;
                 font-size: 8px;
                 transform: translate(0, -50%);      
                 .fa.fa-chevron-down {
+                  position: absolute;
+                  right: 18px;
+                  bottom: 45px;
                   font-size: 17px;
-                  color: #a9a9a9;
-                }
+                  color: #a9a9a9;                }
               }
             }
           }
@@ -166,15 +164,15 @@
                 margin-bottom: 30px;
               }
               &__icon {
-                position: absolute;
-                left: 240px;
-                top: 800px;
                 font-size: 8px;
                 transform: translate(0, -50%);      
                 .fa.fa-chevron-down {
+                  position: absolute;
+                  right: 18px;
+                  bottom: 45px;
                   font-size: 17px;
-                  color: #a9a9a9;
-                }
+                  color: #a9a9a9;                }
+
               }
             }
             &__input-left {


### PR DESCRIPTION
# what
　・_search.scssの更新。
　　検索結果画面の左側のアイコンのズレを修正。
　・GIF画像↓
　　https://gyazo.com/21de0b65fcad3559f66399b9718bb10b

# why
ズレが生じていたため。