### PR TITLE
商品出品時バリデーションメッセージの日本語化の実装

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,16 @@
 ---
 ja:
   activerecord:
+    models:
+      item: アイテム
+    attributes:
+      item:
+        name: 商品名
+        description: 商品説明 
+        delivery_days: 発送までの日数
+        delivery_charge: 配送料の負担
+        price: 価格
+        image: 商品画像
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'


### PR DESCRIPTION
#WHAT
商品出品時バリデーションメッセージの日本語化

#WHY
商品出品時バリデーションメッセージが英語だったため